### PR TITLE
Fix initialization of texture sampler.

### DIFF
--- a/source/gfx/SplashScreenDrawer.cpp
+++ b/source/gfx/SplashScreenDrawer.cpp
@@ -209,8 +209,7 @@ SplashScreenDrawer::SplashScreenDrawer(const std::filesystem::path &splash_base_
     memcpy(coordsUploadBuffer, mTexCoords, mTexCoordBuffer.elemSize * mTexCoordBuffer.elemCount);
     GX2RUnlockBufferEx(&mTexCoordBuffer, GX2R_RESOURCE_BIND_NONE);
 
-    GX2Sampler sampler;
-    GX2InitSampler(&sampler, GX2_TEX_CLAMP_MODE_CLAMP, GX2_TEX_XY_FILTER_MODE_LINEAR);
+    GX2InitSampler(&mSampler, GX2_TEX_CLAMP_MODE_CLAMP, GX2_TEX_XY_FILTER_MODE_LINEAR);
 }
 
 void SplashScreenDrawer::Draw() {


### PR DESCRIPTION
The code was not initializing the `mSampler` member variable, but a local variable. That made the texture be rendered with nearest-neighbor filtering, instead of the intended linear filtering.