### PR TITLE
Update to turbojpeg 3.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/wiiu-env/devkitppc:20241128
+FROM ghcr.io/wiiu-env/devkitppc:20260204
 
 WORKDIR project

--- a/source/crt.c
+++ b/source/crt.c
@@ -2,8 +2,6 @@ void __init_wut_malloc();
 
 void __init_wut_newlib();
 
-void __init_wut_stdcpp();
-
 void __init_wut_devoptab();
 
 void __attribute__((weak)) __init_wut_socket();
@@ -11,8 +9,6 @@ void __attribute__((weak)) __init_wut_socket();
 void __fini_wut_malloc();
 
 void __fini_wut_newlib();
-
-void __fini_wut_stdcpp();
 
 void __fini_wut_devoptab();
 
@@ -24,7 +20,6 @@ void __attribute__((weak))
 __init_wut_() {
     __init_wut_malloc();
     __init_wut_newlib();
-    __init_wut_stdcpp();
     __init_wut_devoptab();
     if (&__init_wut_socket) __init_wut_socket();
 }
@@ -33,7 +28,6 @@ void __attribute__((weak))
 __fini_wut_() {
     __fini();
     __fini_wut_devoptab();
-    __fini_wut_stdcpp();
     __fini_wut_newlib();
     __fini_wut_malloc();
 }

--- a/source/crt.c
+++ b/source/crt.c
@@ -2,6 +2,8 @@ void __init_wut_malloc();
 
 void __init_wut_newlib();
 
+void __init_wut_thread();
+
 void __init_wut_devoptab();
 
 void __attribute__((weak)) __init_wut_socket();
@@ -18,6 +20,7 @@ void __attribute__((weak)) __fini_wut_socket();
 
 void __attribute__((weak))
 __init_wut_() {
+    __init_wut_thread();
     __init_wut_malloc();
     __init_wut_newlib();
     __init_wut_devoptab();

--- a/source/gfx/JPEGTexture.cpp
+++ b/source/gfx/JPEGTexture.cpp
@@ -65,10 +65,10 @@ GX2Texture *JPEG_LoadTexture(std::span<uint8_t> data) {
     }
 
     if (tj3Decompress8(handle,
-                      data.data(), data.size(),
-                      static_cast<unsigned char *>(texture->surface.image),
-                      texture->surface.pitch * 4,
-                      TJPF_RGBA)) {
+                       data.data(), data.size(),
+                       static_cast<unsigned char *>(texture->surface.image),
+                       texture->surface.pitch * 4,
+                       TJPF_RGBA)) {
         DEBUG_FUNCTION_LINE_ERR("Failed to read JPEG image: %s\n", tj3GetErrorStr(handle));
         goto error;
     }

--- a/source/gfx/JPEGTexture.cpp
+++ b/source/gfx/JPEGTexture.cpp
@@ -7,21 +7,23 @@
 
 GX2Texture *JPEG_LoadTexture(std::span<uint8_t> data) {
     GX2Texture *texture = nullptr;
-
-    tjhandle handle = tjInitDecompress();
-    if (!handle) {
-        return nullptr;
-    }
-
     int height;
     int width;
-    int subsamp;
-    int colorspace;
-    if (tjDecompressHeader3(handle,
-                            data.data(), data.size(),
-                            &width, &height,
-                            &subsamp, &colorspace)) {
-        DEBUG_FUNCTION_LINE_ERR("Failed to parse JPEG header\n");
+
+    tjhandle handle = tj3Init(TJINIT_DECOMPRESS);
+    if (!handle) {
+        goto error;
+    }
+
+    if (tj3DecompressHeader(handle, data.data(), data.size())) {
+        DEBUG_FUNCTION_LINE_ERR("Failed to parse JPEG header: %s\n", tj3GetErrorStr(handle));
+        goto error;
+    }
+
+    width = tj3Get(handle, TJPARAM_JPEGWIDTH);
+    height = tj3Get(handle, TJPARAM_JPEGHEIGHT);
+    if (width == -1 || height == -1) {
+        DEBUG_FUNCTION_LINE_ERR("Unknown JPEG image size\n");
         goto error;
     }
 
@@ -62,19 +64,16 @@ GX2Texture *JPEG_LoadTexture(std::span<uint8_t> data) {
         goto error;
     }
 
-    if (tjDecompress2(handle,
+    if (tj3Decompress8(handle,
                       data.data(), data.size(),
                       static_cast<unsigned char *>(texture->surface.image),
-                      width,
                       texture->surface.pitch * 4,
-                      height,
-                      TJPF_RGBA,
-                      0)) {
-        DEBUG_FUNCTION_LINE_ERR("Failed to read JPEG image\n");
+                      TJPF_RGBA)) {
+        DEBUG_FUNCTION_LINE_ERR("Failed to read JPEG image: %s\n", tj3GetErrorStr(handle));
         goto error;
     }
 
-    tjDestroy(handle);
+    tj3Destroy(handle);
 
     GX2Invalidate(GX2_INVALIDATE_MODE_CPU | GX2_INVALIDATE_MODE_TEXTURE,
                   texture->surface.image, texture->surface.imageSize);
@@ -86,6 +85,6 @@ error:
         std::free(texture->surface.image);
     }
     std::free(texture);
-    tjDestroy(handle);
+    tj3Destroy(handle);
     return nullptr;
 }

--- a/source/gfx/JPEGTexture.cpp
+++ b/source/gfx/JPEGTexture.cpp
@@ -20,7 +20,7 @@ GX2Texture *JPEG_LoadTexture(std::span<uint8_t> data) {
         goto error;
     }
 
-    width = tj3Get(handle, TJPARAM_JPEGWIDTH);
+    width  = tj3Get(handle, TJPARAM_JPEGWIDTH);
     height = tj3Get(handle, TJPARAM_JPEGHEIGHT);
     if (width == -1 || height == -1) {
         DEBUG_FUNCTION_LINE_ERR("Unknown JPEG image size\n");

--- a/source/gfx/gfx.c
+++ b/source/gfx/gfx.c
@@ -200,7 +200,7 @@ static BOOL initBucketHeap() {
 
     sGfxHeapForeground = MEMCreateExpHeapEx(base, size, 0);
     if (!sGfxHeapForeground) {
-        WHBLogPrintf("%s: MEMCreateExpHeapEx(0x%08X, 0x%X, 0)", __FUNCTION__, base, size);
+        WHBLogPrintf("%s: MEMCreateExpHeapEx(0x%p, 0x%X, 0)", __FUNCTION__, base, size);
         return FALSE;
     }
 

--- a/source/gfx/gfx.c
+++ b/source/gfx/gfx.c
@@ -200,7 +200,7 @@ static BOOL initBucketHeap() {
 
     sGfxHeapForeground = MEMCreateExpHeapEx(base, size, 0);
     if (!sGfxHeapForeground) {
-        WHBLogPrintf("%s: MEMCreateExpHeapEx(0x%p, 0x%X, 0)", __FUNCTION__, base, size);
+        WHBLogPrintf("%s: MEMCreateExpHeapEx(%p, 0x%X, 0)", __FUNCTION__, base, size);
         return FALSE;
     }
 


### PR DESCRIPTION
This updates the JPEG loader to use the `tj3*()` functions, from turbojpeg 3.0+.

The `ppc-libjpeg-turbo` package from Extrems' repo (https://github.com/extremscorner/pacman-packages) is needed, since the devkitPro repo is still on 2.1.2.