### PR TITLE
Use an environment-agnostic path.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ CXXFLAGS	:= $(CFLAGS) -std=c++23 -fno-rtti
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-g $(ARCH) $(RPXSPECS) --entry=_start -Wl,-Map,$(notdir $*.map)
 
-LIBS	:= -lpng -lwut -lz
+LIBS	:= -lpng -lturbojpeg -lwut -lz
 
 ifeq ($(DEBUG),1)
 CXXFLAGS += -DDEBUG -g

--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ other modules of the environment are loading.
 Place the `01_splashscreen.rpx` in the `[ENVIRONMENT]/modules/setup` folder and run the
 EnvironmentLoader. The module will attempt to load the splash image, in this order:
   1. `[ENVIRONMENT]/splash.png`
-  2. `[ENVIRONMENT]/splash.tga`
-  3. A random image from the directory `[ENVIRONMENT]/splashes/`.
+  2. `[ENVIRONMENT]/splash.jpg` or `[ENVIRONMENT]/splash.jpeg`
+  3. `[ENVIRONMENT]/splash.tga`
+  4. A random image (PNG, JPEG or TGA) from the directory `[ENVIRONMENT]/splashes/`.
 
-If no splash screen is found on the sd card, this module will effectively do nothing.
+If no splash image is found on the sd card, this module will effectively do nothing.
 
 **Notes:**
   - `[ENVIRONMENT]` is the directory of the environment, for Aroma with would be `sd:/wiiu/enviroments/aroma/splash.png`
@@ -22,14 +23,19 @@ If no splash screen is found on the sd card, this module will effectively do not
 ### Logging
 Building via `make` only logs errors (via OSReport). To enable logging via the [LoggingModule](https://github.com/wiiu-env/LoggingModule) set `DEBUG` to `1` or `VERBOSE`.
 
-`make` Logs errors only (via OSReport).  
-`make DEBUG=1` Enables information and error logging via [LoggingModule](https://github.com/wiiu-env/LoggingModule).  
-`make DEBUG=VERBOSE` Enables verbose information and error logging via [LoggingModule](https://github.com/wiiu-env/LoggingModule).
+  - `make` Logs errors only (via OSReport).
+  - `make DEBUG=1` Enables information and error logging via [LoggingModule](https://github.com/wiiu-env/LoggingModule).
+  - `make DEBUG=VERBOSE` Enables verbose information and error logging via [LoggingModule](https://github.com/wiiu-env/LoggingModule).
 
 If the [LoggingModule](https://github.com/wiiu-env/LoggingModule) is not present, it'll fall back to UDP (Port 4405) and [CafeOS](https://github.com/wiiu-env/USBSerialLoggingModule) logging.
 
 ## Building
-For building, you just need [wut](https://github.com/devkitPro/wut/) installed, then use the `make` command.
+For building, you need to install (via devkitPro's `pacman`):
+  - [wut](https://github.com/devkitPro/wut/)
+  - ppc-libpng
+  - ppc-libjpeg-turbo
+
+Then use the `make` command.
 
 ## Building using the Dockerfile
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@ This module is supposed to be loaded with the [EnvironmentLoader](https://github
 other modules of the environment are loading.
 
 ## Usage
-Place the `01_splashscreen.rpx` in the `[ENVIRONMENT]/modules/setup` folder and run the
-EnvironmentLoader.
-
-Place your splash images in the folder `SD:/wiiu/splashes/`. One of them will be randomly
-loaded during boot.
+  1. Place the `01_splashscreen.rpx` in the `[ENVIRONMENT]/modules/setup` folder and run
+     the EnvironmentLoader.
+  2. Place your splash images in the folder `SD:/wiiu/splashes/`. One of them will be randomly
+     loaded during boot.
 
 **Notes:**
   - `[ENVIRONMENT]` is the directory of the environment, for Aroma with would be `SD:/wiiu/enviroments/aroma`.

--- a/README.md
+++ b/README.md
@@ -5,18 +5,25 @@ other modules of the environment are loading.
 
 ## Usage
 Place the `01_splashscreen.rpx` in the `[ENVIRONMENT]/modules/setup` folder and run the
-EnvironmentLoader. The module will attempt to load the splash image, in this order:
-  1. `[ENVIRONMENT]/splash.png`
-  2. `[ENVIRONMENT]/splash.jpg` or `[ENVIRONMENT]/splash.jpeg`
-  3. `[ENVIRONMENT]/splash.tga`
-  4. A random image (PNG, JPEG or TGA) from the directory `[ENVIRONMENT]/splashes/`.
+EnvironmentLoader.
 
-If no splash image is found on the sd card, this module will effectively do nothing.
+Place your splash images in the folder `SD:/wiiu/splashes/`. One of them will be randomly
+loaded during boot.
 
 **Notes:**
-  - `[ENVIRONMENT]` is the directory of the environment, for Aroma with would be `sd:/wiiu/enviroments/aroma/splash.png`
-  - When using a `tga` make sure its 24 bit and uncompressed
-  - In theory any (reasonable) resolution is supported, something like 1280x720 is recommended
+  - `[ENVIRONMENT]` is the directory of the environment, for Aroma with would be `SD:/wiiu/enviroments/aroma`.
+  - When using a `tga` image, make sure its 24 bit and uncompressed,
+  - In theory any (reasonable) resolution is supported, something like 1280x720 is recommended.
+
+## Path priority
+The module will attempt to load a splash image from multiple places, in this order:
+  1. `[ENVIRONMENT]/splash.{png,jpg,jpeg,tga}`
+  2. `[ENVIRONMENT]/splashes/*.{png,jpg,jpeg,tga}`
+  3. `SD:/wiiu/splash.{png,jpg,jpeg,tga}`
+  4. `SD:/wiiu/splashes/*.{png,jpg,jpeg,tga}`
+
+You should use the last path (`SD:/wiiu/splashes/`), and leave the others for when you
+want to override the splash.
 
 ## Buildflags
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ other modules of the environment are loading.
 
 ## Usage
   1. Place the `01_splashscreen.rpx` in the `[ENVIRONMENT]/modules/setup` folder.
-  2. Place your splash images (PNG, TGA, JPEG)) in the folder `SD:/wiiu/splashes/`.
+  2. Place your splash images (PNG, TGA or JPEG) in the folder `SD:/wiiu/splashes/`.
 
 **Notes:**
   - `[ENVIRONMENT]` is the directory of the environment, for Aroma with would be `SD:/wiiu/enviroments/aroma`.

--- a/README.md
+++ b/README.md
@@ -4,22 +4,20 @@ This module is supposed to be loaded with the [EnvironmentLoader](https://github
 other modules of the environment are loading.
 
 ## Usage
-  1. Place the `01_splashscreen.rpx` in the `[ENVIRONMENT]/modules/setup` folder and run
-     the EnvironmentLoader.
-  2. Place your splash images in the folder `SD:/wiiu/splashes/`. One of them will be randomly
-     loaded during boot.
+  1. Place the `01_splashscreen.rpx` in the `[ENVIRONMENT]/modules/setup` folder.
+  2. Place your splash images (PNG, TGA, JPEG)) in the folder `SD:/wiiu/splashes/`.
 
 **Notes:**
   - `[ENVIRONMENT]` is the directory of the environment, for Aroma with would be `SD:/wiiu/enviroments/aroma`.
-  - When using a `tga` image, make sure its 24 bit and uncompressed,
+  - When using a TGA image, make sure its 24 bit and uncompressed,
   - In theory any (reasonable) resolution is supported, something like 1280x720 is recommended.
 
 ## Path priority
 The module will attempt to load a splash image from multiple places, in this order:
   1. `[ENVIRONMENT]/splash.{png,jpg,jpeg,tga}`
-  2. `[ENVIRONMENT]/splashes/*.{png,jpg,jpeg,tga}`
+  2. `[ENVIRONMENT]/splashes/*.{png,jpg,jpeg,tga}` (selected randomly)
   3. `SD:/wiiu/splash.{png,jpg,jpeg,tga}`
-  4. `SD:/wiiu/splashes/*.{png,jpg,jpeg,tga}`
+  4. `SD:/wiiu/splashes/*.{png,jpg,jpeg,tga}` (selected randomly)
 
 You should use the last path (`SD:/wiiu/splashes/`), and leave the others for when you
 want to override the splash.

--- a/source/gfx/JPEGTexture.cpp
+++ b/source/gfx/JPEGTexture.cpp
@@ -1,0 +1,84 @@
+#include "JPEGTexture.h"
+#include <cstdlib>
+#include <cstring>
+#include <gx2/mem.h>
+#include <turbojpeg.h>
+
+GX2Texture *JPEG_LoadTexture(std::span<uint8_t> data) {
+    GX2Texture *texture = nullptr;
+
+    tjhandle handle = tjInitDecompress();
+    if (!handle) {
+        return nullptr;
+    }
+
+    int height;
+    int width;
+    int subsamp;
+    int colorspace;
+    if (tjDecompressHeader3(handle,
+                            data.data(), data.size(),
+                            &width, &height,
+                            &subsamp, &colorspace)) {
+        goto error;
+    }
+
+    texture = static_cast<GX2Texture *>(std::malloc(sizeof(GX2Texture)));
+    if (!texture) {
+        goto error;
+    }
+
+    std::memset(texture, 0, sizeof(GX2Texture));
+    texture->surface.width     = width;
+    texture->surface.height    = height;
+    texture->surface.depth     = 1;
+    texture->surface.mipLevels = 1;
+    texture->surface.format    = GX2_SURFACE_FORMAT_UNORM_R8_G8_B8_A8;
+    texture->surface.aa        = GX2_AA_MODE1X;
+    texture->surface.use       = GX2_SURFACE_USE_TEXTURE;
+    texture->surface.dim       = GX2_SURFACE_DIM_TEXTURE_2D;
+    texture->surface.tileMode  = GX2_TILE_MODE_LINEAR_ALIGNED;
+    texture->surface.swizzle   = 0;
+    texture->viewFirstMip      = 0;
+    texture->viewNumMips       = 1;
+    texture->viewFirstSlice    = 0;
+    texture->viewNumSlices     = 1;
+    texture->compMap           = 0x0010203;
+    GX2CalcSurfaceSizeAndAlignment(&texture->surface);
+    GX2InitTextureRegs(texture);
+
+    if (texture->surface.imageSize == 0) {
+        goto error;
+    }
+
+    texture->surface.image = std::aligned_alloc(texture->surface.alignment,
+                                                texture->surface.imageSize);
+    if (!texture->surface.image) {
+        goto error;
+    }
+
+    if (tjDecompress2(handle,
+                      data.data(), data.size(),
+                      static_cast<unsigned char *>(texture->surface.image),
+                      width,
+                      texture->surface.pitch * 4,
+                      height,
+                      TJPF_RGBA,
+                      0)) {
+        goto error;
+    }
+
+    tjDestroy(handle);
+
+    GX2Invalidate(GX2_INVALIDATE_MODE_CPU | GX2_INVALIDATE_MODE_TEXTURE,
+                  texture->surface.image, texture->surface.imageSize);
+    return texture;
+
+error:
+    if (texture) {
+        std::free(texture->surface.image);
+    }
+    std::free(texture);
+    tjDestroy(handle);
+    return nullptr;
+}

--- a/source/gfx/JPEGTexture.cpp
+++ b/source/gfx/JPEGTexture.cpp
@@ -1,4 +1,5 @@
 #include "JPEGTexture.h"
+#include "utils/logger.h"
 #include <cstdlib>
 #include <cstring>
 #include <gx2/mem.h>
@@ -20,11 +21,13 @@ GX2Texture *JPEG_LoadTexture(std::span<uint8_t> data) {
                             data.data(), data.size(),
                             &width, &height,
                             &subsamp, &colorspace)) {
+        DEBUG_FUNCTION_LINE_ERR("Failed to parse JPEG header\n");
         goto error;
     }
 
     texture = static_cast<GX2Texture *>(std::malloc(sizeof(GX2Texture)));
     if (!texture) {
+        DEBUG_FUNCTION_LINE_ERR("Failed to allocate texture\n");
         goto error;
     }
 
@@ -48,12 +51,14 @@ GX2Texture *JPEG_LoadTexture(std::span<uint8_t> data) {
     GX2InitTextureRegs(texture);
 
     if (texture->surface.imageSize == 0) {
+        DEBUG_FUNCTION_LINE_ERR("Texture is empty\n");
         goto error;
     }
 
     texture->surface.image = std::aligned_alloc(texture->surface.alignment,
                                                 texture->surface.imageSize);
     if (!texture->surface.image) {
+        DEBUG_FUNCTION_LINE_ERR("Failed to allocate surface for texture\n");
         goto error;
     }
 
@@ -65,6 +70,7 @@ GX2Texture *JPEG_LoadTexture(std::span<uint8_t> data) {
                       height,
                       TJPF_RGBA,
                       0)) {
+        DEBUG_FUNCTION_LINE_ERR("Failed to read JPEG image\n");
         goto error;
     }
 
@@ -72,6 +78,7 @@ GX2Texture *JPEG_LoadTexture(std::span<uint8_t> data) {
 
     GX2Invalidate(GX2_INVALIDATE_MODE_CPU | GX2_INVALIDATE_MODE_TEXTURE,
                   texture->surface.image, texture->surface.imageSize);
+
     return texture;
 
 error:

--- a/source/gfx/JPEGTexture.h
+++ b/source/gfx/JPEGTexture.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <cstdint>
+#include <gx2/texture.h>
+#include <span>
+
+GX2Texture *JPEG_LoadTexture(std::span<uint8_t> data);

--- a/source/gfx/SplashScreenDrawer.cpp
+++ b/source/gfx/SplashScreenDrawer.cpp
@@ -1,4 +1,5 @@
 #include "SplashScreenDrawer.h"
+#include "JPEGTexture.h"
 #include "PNGTexture.h"
 #include "ShaderSerializer.h"
 #include "TGATexture.h"
@@ -7,6 +8,7 @@
 #include "utils/utils.h"
 #include <cctype>
 #include <coreinit/time.h>
+#include <cstdlib>
 #include <gx2/draw.h>
 #include <gx2/mem.h>
 #include <gx2r/draw.h>
@@ -131,6 +133,8 @@ static GX2Texture *LoadImageAsTexture(const std::filesystem::path &filename) {
         auto ext = ToLower(filename.extension());
         if (ext == ".png") {
             return PNG_LoadTexture(buffer);
+        } else if (ext == ".jpg" || ext == ".jpeg") {
+            return JPEG_LoadTexture(buffer);
         } else if (ext == ".tga") {
             return TGA_LoadTexture(buffer);
         }
@@ -140,6 +144,12 @@ static GX2Texture *LoadImageAsTexture(const std::filesystem::path &filename) {
 
 SplashScreenDrawer::SplashScreenDrawer(const std::filesystem::path &splash_base_path) {
     mTexture = LoadImageAsTexture(splash_base_path / "splash.png");
+    if (!mTexture) {
+        mTexture = LoadImageAsTexture(splash_base_path / "splash.jpg");
+    }
+    if (!mTexture) {
+        mTexture = LoadImageAsTexture(splash_base_path / "splash.jpeg");
+    }
     if (!mTexture) {
         mTexture = LoadImageAsTexture(splash_base_path / "splash.tga");
     }
@@ -152,7 +162,7 @@ SplashScreenDrawer::SplashScreenDrawer(const std::filesystem::path &splash_base_
                     continue;
                 }
                 auto ext = ToLower(entry.path().extension());
-                if (ext == ".png" || ext == ".tga") {
+                if (ext == ".png" || ext == ".tga" || ext == ".jpg" || ext == ".jpeg") {
                     candidates.push_back(entry.path());
                 }
             }
@@ -241,10 +251,10 @@ SplashScreenDrawer::~SplashScreenDrawer() {
     GX2RDestroyBufferEx(&mTexCoordBuffer, GX2R_RESOURCE_BIND_NONE);
     if (mTexture) {
         if (mTexture->surface.image != nullptr) {
-            free(mTexture->surface.image);
+            std::free(mTexture->surface.image);
             mTexture->surface.image = nullptr;
         }
-        ::free(mTexture);
+        std::free(mTexture);
         mTexture = nullptr;
     }
 }

--- a/source/gfx/SplashScreenDrawer.cpp
+++ b/source/gfx/SplashScreenDrawer.cpp
@@ -142,8 +142,7 @@ static GX2Texture *LoadImageAsTexture(const std::filesystem::path &filename) {
     return nullptr;
 }
 
-SplashScreenDrawer::SplashScreenDrawer()
-{
+SplashScreenDrawer::SplashScreenDrawer() {
     mTexture = PNG_LoadTexture(empty_png);
     InitResources();
 }

--- a/source/gfx/SplashScreenDrawer.h
+++ b/source/gfx/SplashScreenDrawer.h
@@ -11,7 +11,6 @@
 
 class SplashScreenDrawer {
 public:
-
     SplashScreenDrawer();
     explicit SplashScreenDrawer(const std::filesystem::path &baseDir);
 

--- a/source/gfx/SplashScreenDrawer.h
+++ b/source/gfx/SplashScreenDrawer.h
@@ -11,7 +11,9 @@
 
 class SplashScreenDrawer {
 public:
-    explicit SplashScreenDrawer(const std::filesystem::path &meta_dir);
+
+    SplashScreenDrawer();
+    explicit SplashScreenDrawer(const std::filesystem::path &baseDir);
 
     void Draw();
 
@@ -47,4 +49,6 @@ private:
     GX2RBuffer mTexCoordBuffer = {};
     GX2Texture *mTexture       = nullptr;
     GX2Sampler mSampler        = {};
+
+    void InitResources();
 };

--- a/source/gfx/gfx.c
+++ b/source/gfx/gfx.c
@@ -200,7 +200,7 @@ static BOOL initBucketHeap() {
 
     sGfxHeapForeground = MEMCreateExpHeapEx(base, size, 0);
     if (!sGfxHeapForeground) {
-        WHBLogPrintf("%s: MEMCreateExpHeapEx(0x%08X, 0x%X, 0)", __FUNCTION__, base, size);
+        WHBLogPrintf("%s: MEMCreateExpHeapEx(%p, 0x%X, 0)", __FUNCTION__, base, size);
         return FALSE;
     }
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -4,7 +4,7 @@
 #include "utils/utils.h"
 #include "version.h"
 
-#define MODULE_VERSION      "v0.2"
+#define MODULE_VERSION      "v0.3"
 #define MODULE_VERSION_FULL MODULE_VERSION SPLASHSCREEN_MODULE_VERSION_EXTRA
 
 int32_t main(int32_t argc, char **argv) {

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -1,10 +1,10 @@
-#include <exception>
 #include "gfx/SplashScreenDrawer.h"
 #include "gfx/gfx.h"
-#include <optional>
 #include "utils/logger.h"
 #include "utils/utils.h"
 #include "version.h"
+#include <exception>
+#include <optional>
 
 #define MODULE_VERSION      "v0.3"
 #define MODULE_VERSION_FULL MODULE_VERSION SPLASHSCREEN_MODULE_VERSION_EXTRA
@@ -22,12 +22,11 @@ int32_t main(int32_t argc, char **argv) {
     GfxInit();
     {
         std::optional<SplashScreenDrawer> splashScreenDrawer;
-        for (const auto& dir : {envDir, path{"fs:/vol/external01/wiiu"}}) {
+        for (const auto &dir : {envDir, path{"fs:/vol/external01/wiiu"}}) {
             try {
                 splashScreenDrawer.emplace(dir);
                 break;
-            }
-            catch (std::exception &e) {
+            } catch (std::exception &e) {
                 DEBUG_FUNCTION_LINE_INFO("Failed to use %s: %s", dir.c_str(), e.what());
             }
         }
@@ -36,7 +35,6 @@ int32_t main(int32_t argc, char **argv) {
             splashScreenDrawer.emplace();
         }
         splashScreenDrawer->Draw();
-
     }
     GfxShutdown();
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -1,5 +1,7 @@
+#include <exception>
 #include "gfx/SplashScreenDrawer.h"
 #include "gfx/gfx.h"
+#include <optional>
 #include "utils/logger.h"
 #include "utils/utils.h"
 #include "version.h"
@@ -11,15 +13,30 @@ int32_t main(int32_t argc, char **argv) {
     initLogging();
     DEBUG_FUNCTION_LINE_INFO("Running SplashScreen Module " MODULE_VERSION_FULL "");
 
-    std::filesystem::path basePath = "fs:/vol/external01/wiiu";
+    using std::filesystem::path;
+    path envDir;
     if (argc >= 1) {
-        basePath = argv[0];
+        envDir = argv[0];
     }
 
     GfxInit();
     {
-        SplashScreenDrawer splashScreenDrawer(basePath);
-        splashScreenDrawer.Draw();
+        std::optional<SplashScreenDrawer> splashScreenDrawer;
+        for (const auto& dir : {envDir, path{"fs:/vol/external01/wiiu"}}) {
+            try {
+                splashScreenDrawer.emplace(dir);
+                break;
+            }
+            catch (std::exception &e) {
+                DEBUG_FUNCTION_LINE_INFO("Failed to use %s: %s", dir.c_str(), e.what());
+            }
+        }
+        // Fallback: use built-in empty splash.
+        if (!splashScreenDrawer) {
+            splashScreenDrawer.emplace();
+        }
+        splashScreenDrawer->Draw();
+
     }
     GfxShutdown();
 


### PR DESCRIPTION
This allows loading splashes from `SD:/wiiu/` directly, like `SD:/wiiu/splash.png` or `SD:/wiiu/splashes/`.

We already have other style/theme folders in the top-level `wiiu` folder, so it makes sense to have the splashes there too.

The environment-specific path will still take precedence. For instance, `SD:/wiiu/environments/experimental-aroma/splash.png` will override any other splash image when loading the `experimental-aroma` environment.