### PR TITLE
Show errors, plus code refactoring.

### DIFF
--- a/source/gfx/JPEGTexture.cpp
+++ b/source/gfx/JPEGTexture.cpp
@@ -1,90 +1,73 @@
 #include "JPEGTexture.h"
-#include "utils/logger.h"
-#include <cstdlib>
-#include <cstring>
-#include <gx2/mem.h>
+#include <stdexcept>
 #include <turbojpeg.h>
 
-GX2Texture *JPEG_LoadTexture(std::span<uint8_t> data) {
-    GX2Texture *texture = nullptr;
-    int height;
-    int width;
+using namespace std::literals;
 
-    tjhandle handle = tj3Init(TJINIT_DECOMPRESS);
-    if (!handle) {
-        goto error;
+struct TJError : std::runtime_error {
+    TJError(tjhandle handle) : std::runtime_error{tj3GetErrorStr(handle)} {}
+};
+
+// RAII wrapper for tjhandle
+class JPEGImage {
+public:
+    JPEGImage() : mHandle{tj3Init(TJINIT_DECOMPRESS)} {
+        if (!mHandle) {
+            throw TJError{mHandle};
+        }
     }
 
-    if (tj3DecompressHeader(handle, data.data(), data.size())) {
-        DEBUG_FUNCTION_LINE_ERR("Failed to parse JPEG header: %s\n", tj3GetErrorStr(handle));
-        goto error;
+    ~JPEGImage() noexcept {
+        if (mHandle)
+            tj3Destroy(mHandle);
     }
 
-    width  = tj3Get(handle, TJPARAM_JPEGWIDTH);
-    height = tj3Get(handle, TJPARAM_JPEGHEIGHT);
-    if (width == -1 || height == -1) {
-        DEBUG_FUNCTION_LINE_ERR("Unknown JPEG image size\n");
-        goto error;
+    void decompressHeader(std::span<const uint8_t> data) {
+        if (tj3DecompressHeader(mHandle, data.data(), data.size())) {
+            throw TJError{mHandle};
+        }
     }
 
-    texture = static_cast<GX2Texture *>(std::malloc(sizeof(GX2Texture)));
-    if (!texture) {
-        DEBUG_FUNCTION_LINE_ERR("Failed to allocate texture\n");
-        goto error;
+    void decompress8(std::span<const uint8_t> data, void *dst,
+                     std::uint32_t rowStride, int pixelFormat) {
+        if (tj3Decompress8(mHandle,
+                           data.data(), data.size(),
+                           static_cast<unsigned char *>(dst),
+                           rowStride,
+                           pixelFormat)) {
+            throw TJError{mHandle};
+        }
     }
 
-    std::memset(texture, 0, sizeof(GX2Texture));
-    texture->surface.width     = width;
-    texture->surface.height    = height;
-    texture->surface.depth     = 1;
-    texture->surface.mipLevels = 1;
-    texture->surface.format    = GX2_SURFACE_FORMAT_UNORM_R8_G8_B8_A8;
-    texture->surface.aa        = GX2_AA_MODE1X;
-    texture->surface.use       = GX2_SURFACE_USE_TEXTURE;
-    texture->surface.dim       = GX2_SURFACE_DIM_TEXTURE_2D;
-    texture->surface.tileMode  = GX2_TILE_MODE_LINEAR_ALIGNED;
-    texture->surface.swizzle   = 0;
-    texture->viewFirstMip      = 0;
-    texture->viewNumMips       = 1;
-    texture->viewFirstSlice    = 0;
-    texture->viewNumSlices     = 1;
-    texture->compMap           = 0x0010203;
-    GX2CalcSurfaceSizeAndAlignment(&texture->surface);
-    GX2InitTextureRegs(texture);
-
-    if (texture->surface.imageSize == 0) {
-        DEBUG_FUNCTION_LINE_ERR("Texture is empty\n");
-        goto error;
+    std::uint32_t getWidth() const {
+        int width = tj3Get(mHandle, TJPARAM_JPEGWIDTH);
+        if (width < 0) {
+            throw std::runtime_error{"Unknown JPEG width"};
+        }
+        return width;
     }
 
-    texture->surface.image = std::aligned_alloc(texture->surface.alignment,
-                                                texture->surface.imageSize);
-    if (!texture->surface.image) {
-        DEBUG_FUNCTION_LINE_ERR("Failed to allocate surface for texture\n");
-        goto error;
+    std::uint32_t getHeight() const {
+        int height = tj3Get(mHandle, TJPARAM_JPEGHEIGHT);
+        if (height < 0) {
+            throw std::runtime_error{"Unknown JPEG height"};
+        }
+        return height;
     }
 
-    if (tj3Decompress8(handle,
-                       data.data(), data.size(),
-                       static_cast<unsigned char *>(texture->surface.image),
-                       texture->surface.pitch * 4,
-                       TJPF_RGBA)) {
-        DEBUG_FUNCTION_LINE_ERR("Failed to read JPEG image: %s\n", tj3GetErrorStr(handle));
-        goto error;
+private:
+    tjhandle mHandle = nullptr;
+}; // class JPEGImage
+
+std::expected<Texture, std::string> JPEG_LoadTexture(std::span<const uint8_t> data) noexcept {
+    try {
+        JPEGImage jpeg;
+        jpeg.decompressHeader(data);
+        Texture texture{jpeg.getWidth(), jpeg.getHeight()};
+        jpeg.decompress8(data, texture.getPixels(), texture.getRowStride(), TJPF_RGBA);
+        texture.flush();
+        return texture;
+    } catch (std::exception &e) {
+        return std::unexpected{"[JPEGTexture] "s + e.what()};
     }
-
-    tj3Destroy(handle);
-
-    GX2Invalidate(GX2_INVALIDATE_MODE_CPU | GX2_INVALIDATE_MODE_TEXTURE,
-                  texture->surface.image, texture->surface.imageSize);
-
-    return texture;
-
-error:
-    if (texture) {
-        std::free(texture->surface.image);
-    }
-    std::free(texture);
-    tj3Destroy(handle);
-    return nullptr;
 }

--- a/source/gfx/JPEGTexture.h
+++ b/source/gfx/JPEGTexture.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "Texture.h"
 #include <cstdint>
-#include <gx2/texture.h>
+#include <expected>
 #include <span>
+#include <string>
 
-GX2Texture *JPEG_LoadTexture(std::span<uint8_t> data);
+std::expected<Texture, std::string> JPEG_LoadTexture(std::span<const uint8_t> data) noexcept;

--- a/source/gfx/PNGTexture.cpp
+++ b/source/gfx/PNGTexture.cpp
@@ -1,79 +1,58 @@
 #include "PNGTexture.h"
-#include "utils/logger.h"
-#include <cstdlib>
-#include <cstring>
-#include <gx2/mem.h>
 #include <png.h>
+#include <stdexcept>
 
-GX2Texture *PNG_LoadTexture(std::span<uint8_t> data) {
-    GX2Texture *texture = nullptr;
+using namespace std::literals;
 
-    png_image image{};
-    image.version = PNG_IMAGE_VERSION;
-
-    if (!png_image_begin_read_from_memory(&image, data.data(), data.size())) {
-        DEBUG_FUNCTION_LINE_ERR("Failed to parse PNG header: %s\n", image.message);
-        goto error;
+// RAII wrapper for png_image
+class PNGImage {
+public:
+    PNGImage() {
+        mImage.version = PNG_IMAGE_VERSION;
     }
 
-    // Request the output to always be RGBA
-    image.format = PNG_FORMAT_RGBA;
-
-    texture = static_cast<GX2Texture *>(std::malloc(sizeof(GX2Texture)));
-    if (!texture) {
-        DEBUG_FUNCTION_LINE_ERR("Failed to allocate texture\n");
-        goto error;
+    ~PNGImage() noexcept {
+        png_image_free(&mImage);
     }
 
-    std::memset(texture, 0, sizeof(GX2Texture));
-    texture->surface.width     = image.width;
-    texture->surface.height    = image.height;
-    texture->surface.depth     = 1;
-    texture->surface.mipLevels = 1;
-    texture->surface.format    = GX2_SURFACE_FORMAT_UNORM_R8_G8_B8_A8;
-    texture->surface.aa        = GX2_AA_MODE1X;
-    texture->surface.use       = GX2_SURFACE_USE_TEXTURE;
-    texture->surface.dim       = GX2_SURFACE_DIM_TEXTURE_2D;
-    texture->surface.tileMode  = GX2_TILE_MODE_LINEAR_ALIGNED;
-    texture->surface.swizzle   = 0;
-    texture->viewFirstMip      = 0;
-    texture->viewNumMips       = 1;
-    texture->viewFirstSlice    = 0;
-    texture->viewNumSlices     = 1;
-    texture->compMap           = 0x0010203;
-    GX2CalcSurfaceSizeAndAlignment(&texture->surface);
-    GX2InitTextureRegs(texture);
-
-    if (texture->surface.imageSize == 0) {
-        DEBUG_FUNCTION_LINE_ERR("Texture is empty\n");
-        goto error;
+    void beginRead(std::span<const uint8_t> data) {
+        if (!png_image_begin_read_from_memory(&mImage, data.data(), data.size())) {
+            throw std::runtime_error{"Failed to parse PNG header: "s + mImage.message};
+        }
     }
 
-    texture->surface.image = std::aligned_alloc(texture->surface.alignment,
-                                                texture->surface.imageSize);
-    if (!texture->surface.image) {
-        DEBUG_FUNCTION_LINE_ERR("Failed to allocate surface for texture\n");
-        goto error;
+    void finishRead(png_const_colorp background, void *dst,
+                    png_int_32 rowStride, void *colormap) {
+        // Request the output to always be RGBA
+        mImage.format = PNG_FORMAT_RGBA;
+        if (!png_image_finish_read(&mImage, background, dst, rowStride, nullptr)) {
+            throw std::runtime_error{"Failed to read PNG image: "s + mImage.message};
+        }
     }
 
-    if (!png_image_finish_read(&image, nullptr,
-                               texture->surface.image,
-                               texture->surface.pitch * 4,
-                               nullptr)) {
-        DEBUG_FUNCTION_LINE_ERR("Failed to read PNG image: %s\n", image.message);
-        goto error;
+    std::uint32_t
+    getWidth() const noexcept {
+        return mImage.width;
     }
 
-    GX2Invalidate(GX2_INVALIDATE_MODE_CPU | GX2_INVALIDATE_MODE_TEXTURE,
-                  texture->surface.image, texture->surface.imageSize);
-
-    return texture;
-
-error:
-    if (texture) {
-        std::free(texture->surface.image);
+    std::uint32_t getHeight() const noexcept {
+        return mImage.height;
     }
-    std::free(texture);
-    png_image_free(&image);
-    return nullptr;
+
+private:
+    png_image mImage{};
+
+}; // class PNGImage
+
+std::expected<Texture, std::string> PNG_LoadTexture(std::span<const uint8_t> data) noexcept {
+    try {
+        PNGImage png;
+        png.beginRead(data);
+        Texture texture{png.getWidth(), png.getHeight()};
+        png.finishRead(nullptr, texture.getPixels(), texture.getRowStride(), nullptr);
+        texture.flush();
+        return texture;
+    } catch (std::exception &e) {
+        return std::unexpected{"[PNGTexture] "s + e.what()};
+    }
 }

--- a/source/gfx/PNGTexture.h
+++ b/source/gfx/PNGTexture.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "Texture.h"
 #include <cstdint>
-#include <gx2/texture.h>
+#include <expected>
 #include <span>
+#include <string>
 
-GX2Texture *PNG_LoadTexture(std::span<uint8_t> data);
+std::expected<Texture, std::string> PNG_LoadTexture(std::span<const uint8_t> data) noexcept;

--- a/source/gfx/SplashScreenDrawer.cpp
+++ b/source/gfx/SplashScreenDrawer.cpp
@@ -10,13 +10,23 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <chrono>
+#include <coreinit/cache.h>
+#include <coreinit/memfrmheap.h>
+#include <coreinit/memheap.h>
+#include <coreinit/memory.h>
+#include <coreinit/screen.h>
 #include <cstdlib>
 #include <exception>
+#include <expected>
 #include <gx2/draw.h>
 #include <gx2/mem.h>
 #include <gx2r/draw.h>
 #include <string>
+#include <thread>
 #include <whb/log.h>
+
+using namespace std::literals;
 
 /*
 constexpr const char *s_textureVertexShader = R"(
@@ -122,7 +132,56 @@ uint8_t empty_png[119] = {
         0x0C, 0x0C, 0x00, 0x00, 0x0E, 0x00, 0x01, 0x7A, 0xB1, 0xB9, 0x30, 0x00,
         0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82};
 
-static GX2Texture *LoadImageAsTexture(const std::filesystem::path &filename) {
+static void reportError(const std::string &msg) {
+    OSScreenInit();
+    auto tvSize  = OSScreenGetBufferSizeEx(SCREEN_TV);
+    auto drcSize = OSScreenGetBufferSizeEx(SCREEN_DRC);
+
+    const auto tag = 0x000DECAF;
+    auto heap      = MEMGetBaseHeapHandle(MEM_BASE_HEAP_MEM1);
+    MEMRecordStateForFrmHeap(heap, tag);
+
+    auto tvBuffer  = MEMAllocFromFrmHeapEx(heap, tvSize, 4);
+    auto drcBuffer = MEMAllocFromFrmHeapEx(heap, drcSize, 4);
+
+    OSScreenSetBufferEx(SCREEN_TV, tvBuffer);
+    OSScreenSetBufferEx(SCREEN_DRC, drcBuffer);
+
+    OSScreenEnableEx(SCREEN_TV, true);
+    OSScreenEnableEx(SCREEN_DRC, true);
+
+    OSScreenClearBufferEx(SCREEN_TV, 0x80'00'00'ff);
+    OSScreenClearBufferEx(SCREEN_DRC, 0x80'00'00'ff);
+
+    // break down the message if too long
+    const std::string::size_type max_line_length = 60;
+    if (msg.size() > max_line_length) {
+        int y = 0;
+        for (std::string::size_type i = 0; i < msg.size(); i += max_line_length, ++y) {
+            auto fragment = msg.substr(i, max_line_length);
+            OSScreenPutFontEx(SCREEN_TV, 0, y, fragment.c_str());
+            OSScreenPutFontEx(SCREEN_DRC, 0, y, fragment.c_str());
+        }
+    } else {
+        OSScreenPutFontEx(SCREEN_TV, 0, 0, msg.c_str());
+        OSScreenPutFontEx(SCREEN_DRC, 0, 0, msg.c_str());
+    }
+
+    DCFlushRange(tvBuffer, tvSize);
+    DCFlushRange(drcBuffer, drcSize);
+    OSScreenFlipBuffersEx(SCREEN_TV);
+    OSScreenFlipBuffersEx(SCREEN_DRC);
+
+    std::this_thread::sleep_for(15s);
+
+    OSScreenEnableEx(SCREEN_TV, false);
+    OSScreenEnableEx(SCREEN_DRC, false);
+
+    OSScreenShutdown();
+    MEMFreeByStateToFrmHeap(heap, tag);
+}
+
+static std::expected<Texture, std::string> LoadImageAsTexture(const std::filesystem::path &filename) {
     std::vector<uint8_t> buffer;
     if (LoadFileIntoBuffer(filename, buffer)) {
         auto ext = ToLower(filename.extension());
@@ -134,9 +193,10 @@ static GX2Texture *LoadImageAsTexture(const std::filesystem::path &filename) {
             return TGA_LoadTexture(buffer);
         } else if (ext == ".webp") {
             return WEBP_LoadTexture(buffer);
-        }
-    }
-    return nullptr;
+        } else
+            return std::unexpected{"Unknown file extension: "s + ext.string()};
+    } else
+        return std::unexpected{"Unable to read file: "s + filename.string() + "\""s};
 }
 
 SplashScreenDrawer::SplashScreenDrawer(const std::filesystem::path &envDir) {
@@ -145,7 +205,15 @@ SplashScreenDrawer::SplashScreenDrawer(const std::filesystem::path &envDir) {
         // 2: Use general dir.
         if (!LoadTextureFrom("fs:/vol/external01/wiiu")) {
             // 3: Use fallback empty texture.
-            mTexture = PNG_LoadTexture(empty_png);
+            auto tex = PNG_LoadTexture(empty_png);
+            if (tex) {
+                mTexture = std::move(*tex);
+            } else {
+                // should never fail to load fallback texture, something is broken
+                DEBUG_FUNCTION_LINE_ERR("Could not load fallback texture: %s",
+                                        tex.error().c_str());
+                abort();
+            }
         }
     }
 
@@ -205,17 +273,30 @@ bool SplashScreenDrawer::LoadTextureFrom(const std::filesystem::path &dir) {
 
     // First try the splash.* image.
     for (const auto &ext : extensions) {
-        auto fname = std::string{"splash"} + ext;
-        mTexture   = LoadImageAsTexture(dir / fname);
-        if (mTexture) {
+        auto filename = dir / ("splash"s + ext);
+        if (!exists(filename))
+            continue;
+        auto tex = LoadImageAsTexture(filename);
+        if (tex) {
+            mTexture = std::move(*tex);
+            return true;
+        } else {
+            DEBUG_FUNCTION_LINE_ERR("Failed to load texture \"%s\": %s\n",
+                                    filename.c_str(),
+                                    tex.error().c_str());
+            reportError("Failed to load texture \"" + filename.string() + "\": " + tex.error());
             return true;
         }
     }
 
+    // Second attempt, the "splashes" directory.
     try {
+        auto search_dir = dir / "splashes";
+        if (!exists(search_dir))
+            return false;
         // Make a list of all candidates in splashes/* to select one at random.
         std::vector<std::filesystem::path> candidates;
-        for (const auto &entry : std::filesystem::directory_iterator{dir / "splashes"}) {
+        for (const auto &entry : std::filesystem::directory_iterator{search_dir}) {
             if (!entry.is_regular_file()) {
                 continue;
             }
@@ -226,13 +307,23 @@ bool SplashScreenDrawer::LoadTextureFrom(const std::filesystem::path &dir) {
         }
         if (!candidates.empty()) {
             auto selected = GetRandomIndex(candidates.size());
-            mTexture      = LoadImageAsTexture(candidates[selected]);
-            if (mTexture) {
+            auto filename = candidates[selected];
+            auto tex      = LoadImageAsTexture(filename);
+            if (tex) {
+                mTexture = std::move(*tex);
+                return true;
+            } else {
+                DEBUG_FUNCTION_LINE_ERR("Failed to load texture \"%s\": %s\n",
+                                        filename.c_str(),
+                                        tex.error().c_str());
+                reportError("Failed to load texture \"" + filename.string() + "\": " + tex.error());
                 return true;
             }
         }
     } catch (std::exception &e) {
-        DEBUG_FUNCTION_LINE_INFO("Loading texture failed: %s", e.what());
+        DEBUG_FUNCTION_LINE_ERR("Loading texture failed: %s", e.what());
+        reportError(e.what());
+        return true; // stop trying to load a texture after this
     }
     return false;
 }
@@ -253,7 +344,7 @@ void SplashScreenDrawer::Draw() {
 
     GX2RSetAttributeBuffer(&mPositionBuffer, 0, mPositionBuffer.elemSize, 0);
     GX2RSetAttributeBuffer(&mTexCoordBuffer, 1, mTexCoordBuffer.elemSize, 0);
-    GX2SetPixelTexture(mTexture, mShaderGroup.pixelShader->samplerVars[0].location);
+    GX2SetPixelTexture(mTexture.get(), mShaderGroup.pixelShader->samplerVars[0].location);
     GX2SetPixelSampler(&mSampler, mShaderGroup.pixelShader->samplerVars[0].location);
 
     GX2DrawEx(GX2_PRIMITIVE_MODE_QUADS, 4, 0, 1);
@@ -264,12 +355,4 @@ void SplashScreenDrawer::Draw() {
 SplashScreenDrawer::~SplashScreenDrawer() {
     GX2RDestroyBufferEx(&mPositionBuffer, GX2R_RESOURCE_BIND_NONE);
     GX2RDestroyBufferEx(&mTexCoordBuffer, GX2R_RESOURCE_BIND_NONE);
-    if (mTexture) {
-        if (mTexture->surface.image != nullptr) {
-            std::free(mTexture->surface.image);
-            mTexture->surface.image = nullptr;
-        }
-        std::free(mTexture);
-        mTexture = nullptr;
-    }
 }

--- a/source/gfx/SplashScreenDrawer.h
+++ b/source/gfx/SplashScreenDrawer.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include "ShaderSerializer.h"
+#include "Texture.h"
 #include "gfx.h"
 #include <filesystem>
 #include <gx2/sampler.h>
 #include <gx2/shaders.h>
-#include <gx2/texture.h>
 #include <gx2r/buffer.h>
 #include <memory>
 
@@ -45,8 +45,8 @@ private:
     std::unique_ptr<GX2PixelShaderWrapper> mPixelShaderWrapper;
     GX2RBuffer mPositionBuffer = {};
     GX2RBuffer mTexCoordBuffer = {};
-    GX2Texture *mTexture       = nullptr;
-    GX2Sampler mSampler        = {};
+    Texture mTexture;
+    GX2Sampler mSampler = {};
 
     void InitResources();
 

--- a/source/gfx/TGATexture.cpp
+++ b/source/gfx/TGATexture.cpp
@@ -1,11 +1,9 @@
-#include <gx2/draw.h>
-#include <gx2/mem.h>
-#include <malloc.h>
-#include <span>
-
 #include "TGATexture.h"
-#include "utils/logger.h"
-#include <whb/log.h>
+#include <cstring>
+#include <stdexcept>
+#include <utility>
+
+using namespace std::literals;
 
 /*
  * Based on
@@ -14,71 +12,64 @@
  * https://github.com/Crementif/WiiU-GX2-Shader-Examples/blob/5a88f861043dcb7666d4d25a6bab6bd271e76d5f/include/TGATexture.h
  */
 
+struct WUT_PACKED TGA_HEADER {
+    uint8_t identsize;     // size of ID field that follows 18 byte header (0 usually)
+    uint8_t colourmaptype; // type of colour map 0=none, 1=has palette
+    uint8_t imagetype;     // type of image 0=none,1=indexed,2=rgb,3=grey,+8=rle packed
+
+    uint8_t colourmapstart[2];  // first colour map entry in palette
+    uint8_t colourmaplength[2]; // number of colours in palette
+    uint8_t colourmapbits;      // number of bits per palette entry 15,16,24,32
+
+    uint16_t xstart;    // image x origin
+    uint16_t ystart;    // image y origin
+    uint16_t width;     // image width in pixels
+    uint16_t height;    // image height in pixels
+    uint8_t bits;       // image bits per pixel 8,16,24,32
+    uint8_t descriptor; // image descriptor bits (vh flip bits)
+};
+
 uint16_t inline _swapU16(uint16_t v) {
     return (v >> 8) | (v << 8);
 }
 
-GX2Texture *TGA_LoadTexture(std::span<uint8_t> data) {
-    TGA_HEADER *tgaHeader = (TGA_HEADER *) data.data();
+std::expected<Texture, std::string> TGA_LoadTexture(std::span<const uint8_t> data) noexcept {
+    try {
+        TGA_HEADER tgaHeader;
+        if (data.size() < sizeof tgaHeader)
+            throw std::runtime_error{"Truncated TGA image"};
+        std::memcpy(&tgaHeader, data.data(), sizeof tgaHeader);
 
-    uint32_t width  = _swapU16(tgaHeader->width);
-    uint32_t height = _swapU16(tgaHeader->height);
+        uint32_t width  = _swapU16(tgaHeader.width);
+        uint32_t height = _swapU16(tgaHeader.height);
 
-    if (tgaHeader->bits != 24) {
-        DEBUG_FUNCTION_LINE_INFO("Only 24bit TGA images are supported");
-        return nullptr;
-    }
-    if (tgaHeader->imagetype != 2 && tgaHeader->imagetype != 3) {
-        DEBUG_FUNCTION_LINE_INFO("Only uncompressed TGA images are supported");
-        return nullptr;
-    }
-
-    GX2Texture *texture = (GX2Texture *) malloc(sizeof(GX2Texture));
-    *texture            = {};
-
-    texture->surface.width     = width;
-    texture->surface.height    = height;
-    texture->surface.depth     = 1;
-    texture->surface.mipLevels = 1;
-    texture->surface.format    = GX2_SURFACE_FORMAT_UNORM_R8_G8_B8_A8;
-    texture->surface.aa        = GX2_AA_MODE1X;
-    texture->surface.use       = GX2_SURFACE_USE_TEXTURE;
-    texture->surface.dim       = GX2_SURFACE_DIM_TEXTURE_2D;
-    texture->surface.tileMode  = GX2_TILE_MODE_LINEAR_ALIGNED;
-    texture->surface.swizzle   = 0;
-    texture->viewFirstMip      = 0;
-    texture->viewNumMips       = 1;
-    texture->viewFirstSlice    = 0;
-    texture->viewNumSlices     = 1;
-    texture->compMap           = 0x0010203;
-    GX2CalcSurfaceSizeAndAlignment(&texture->surface);
-    GX2InitTextureRegs(texture);
-
-    if (texture->surface.imageSize == 0) {
-        return nullptr;
-    }
-
-    texture->surface.image = memalign(texture->surface.alignment, texture->surface.imageSize);
-    if (!texture->surface.image) {
-        return nullptr;
-    }
-
-    for (uint32_t y = 0; y < height; y++) {
-        uint32_t *out_data = (uint32_t *) texture->surface.image + (y * texture->surface.pitch);
-        for (uint32_t x = 0; x < width; x++) {
-            int index = sizeof(TGA_HEADER) + (3 * width * (height - 1 - y)) + (3 * x);
-
-            int b = data[index + 0] & 0xFF;
-            int g = data[index + 1] & 0xFF;
-            int r = data[index + 2] & 0xFF;
-
-            *out_data = r << 24 | g << 16 | b << 8 | 0xFF;
-            out_data++;
+        if (tgaHeader.bits != 24) {
+            throw std::runtime_error{"Only 24bit TGA images are supported"};
         }
+        if (tgaHeader.imagetype != 2 && tgaHeader.imagetype != 3) {
+            throw std::runtime_error{"Only uncompressed TGA images are supported"};
+        }
+
+        Texture texture{width, height};
+
+        for (uint32_t y = 0; y < height; y++) {
+            uint32_t *row = texture.getRow(y);
+            for (uint32_t x = 0; x < width; x++) {
+                size_t index = sizeof(TGA_HEADER) + (3 * width * (height - 1 - y)) + (3 * x);
+
+                int b = data[index + 0] & 0xFF;
+                int g = data[index + 1] & 0xFF;
+                int r = data[index + 2] & 0xFF;
+
+                row[x] = r << 24 | g << 16 | b << 8 | 0xFF;
+            }
+        }
+
+        // todo: create texture with optimal tile format and use GX2CopySurface to convert from linear to tiled format
+
+        texture.flush();
+        return texture;
+    } catch (std::exception &e) {
+        return std::unexpected{"[TGATexture] "s + e.what()};
     }
-
-    // todo: create texture with optimal tile format and use GX2CopySurface to convert from linear to tiled format
-    GX2Invalidate(GX2_INVALIDATE_MODE_CPU | GX2_INVALIDATE_MODE_TEXTURE, texture->surface.image, texture->surface.imageSize);
-
-    return texture;
 }

--- a/source/gfx/TGATexture.h
+++ b/source/gfx/TGATexture.h
@@ -1,24 +1,10 @@
 #pragma once
 
+#include "Texture.h"
 #include <cstdint>
-#include <gx2/texture.h>
-
-struct WUT_PACKED TGA_HEADER {
-    uint8_t identsize;     // size of ID field that follows 18 byte header (0 usually)
-    uint8_t colourmaptype; // type of colour map 0=none, 1=has palette
-    uint8_t imagetype;     // type of image 0=none,1=indexed,2=rgb,3=grey,+8=rle packed
-
-    uint8_t colourmapstart[2];  // first colour map entry in palette
-    uint8_t colourmaplength[2]; // number of colours in palette
-    uint8_t colourmapbits;      // number of bits per palette entry 15,16,24,32
-
-    uint16_t xstart;    // image x origin
-    uint16_t ystart;    // image y origin
-    uint16_t width;     // image width in pixels
-    uint16_t height;    // image height in pixels
-    uint8_t bits;       // image bits per pixel 8,16,24,32
-    uint8_t descriptor; // image descriptor bits (vh flip bits)
-};
+#include <expected>
+#include <span>
+#include <string>
 
 // quick and dirty 24-bit TGA loader
-GX2Texture *TGA_LoadTexture(std::span<uint8_t> data);
+std::expected<Texture, std::string> TGA_LoadTexture(std::span<const uint8_t> data) noexcept;

--- a/source/gfx/Texture.cpp
+++ b/source/gfx/Texture.cpp
@@ -1,0 +1,78 @@
+#include "Texture.h"
+#include <cstdlib>
+#include <cstring>
+#include <gx2/mem.h>
+#include <stdexcept>
+
+Texture::Texture(std::uint32_t width, std::uint32_t height) : mTexture{std::make_unique<GX2Texture>()} {
+    std::memset(mTexture.get(), 0, sizeof *mTexture);
+    mTexture->surface.width     = width;
+    mTexture->surface.height    = height;
+    mTexture->surface.depth     = 1;
+    mTexture->surface.mipLevels = 1;
+    mTexture->surface.format    = GX2_SURFACE_FORMAT_UNORM_R8_G8_B8_A8;
+    mTexture->surface.aa        = GX2_AA_MODE1X;
+    mTexture->surface.use       = GX2_SURFACE_USE_TEXTURE;
+    mTexture->surface.dim       = GX2_SURFACE_DIM_TEXTURE_2D;
+    mTexture->surface.tileMode  = GX2_TILE_MODE_LINEAR_ALIGNED;
+    mTexture->surface.swizzle   = 0;
+    mTexture->viewFirstMip      = 0;
+    mTexture->viewNumMips       = 1;
+    mTexture->viewFirstSlice    = 0;
+    mTexture->viewNumSlices     = 1;
+    mTexture->compMap           = 0x0010203;
+    GX2CalcSurfaceSizeAndAlignment(&mTexture->surface);
+    GX2InitTextureRegs(mTexture.get());
+
+    if (mTexture->surface.imageSize == 0) {
+        throw std::runtime_error{"Texture is empty"};
+    }
+
+    mTexture->surface.image = std::aligned_alloc(mTexture->surface.alignment,
+                                                 mTexture->surface.imageSize);
+    if (!mTexture->surface.image) {
+        throw std::runtime_error{"Failed to allocate surface for texture"};
+    }
+}
+
+Texture::~Texture() noexcept {
+    if (mTexture) {
+        std::free(mTexture->surface.image);
+    }
+}
+
+GX2Texture *
+Texture::get() noexcept {
+    return mTexture.get();
+}
+
+void Texture::flush() noexcept {
+    GX2Invalidate(GX2_INVALIDATE_MODE_CPU | GX2_INVALIDATE_MODE_TEXTURE,
+                  getPixels(),
+                  getSize());
+}
+
+void *Texture::getPixels() noexcept {
+    return mTexture->surface.image;
+}
+
+std::size_t Texture::getSize() const noexcept {
+    return mTexture->surface.imageSize;
+}
+
+std::uint32_t Texture::getRowPitch() noexcept {
+    return mTexture->surface.pitch;
+}
+
+std::uint32_t Texture::getRowStride() noexcept {
+    return getRowPitch() * 4;
+}
+
+uint32_t *Texture::getRow(uint32_t y) noexcept {
+    uint32_t *pixels = reinterpret_cast<uint32_t *>(getPixels());
+    return &pixels[y * getRowPitch()];
+}
+
+Texture::operator bool() const noexcept {
+    return !!mTexture;
+}

--- a/source/gfx/Texture.h
+++ b/source/gfx/Texture.h
@@ -7,7 +7,7 @@
 class Texture {
 public:
     // allow moving
-    Texture(Texture &&other) noexcept            = default;
+    Texture(Texture &&other) noexcept = default;
     Texture &operator=(Texture &&other) noexcept = default;
 
     Texture() noexcept = default;

--- a/source/gfx/Texture.h
+++ b/source/gfx/Texture.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cstdint>
+#include <gx2/texture.h>
+#include <memory>
+
+class Texture {
+public:
+    // allow moving
+    Texture(Texture &&other) noexcept            = default;
+    Texture &operator=(Texture &&other) noexcept = default;
+
+    Texture() noexcept = default;
+
+    Texture(std::uint32_t width, std::uint32_t height);
+
+    ~Texture() noexcept;
+
+    GX2Texture *get() noexcept;
+
+    void flush() noexcept;
+
+    void *getPixels() noexcept;
+
+    std::size_t getSize() const noexcept;
+
+    // size of a row, in pixels
+    std::uint32_t getRowPitch() noexcept;
+
+    // size of a row, in bytes
+    std::uint32_t getRowStride() noexcept;
+
+    uint32_t *getRow(uint32_t y) noexcept;
+
+    explicit operator bool() const noexcept;
+
+private:
+    std::unique_ptr<GX2Texture> mTexture;
+
+}; // class Texture

--- a/source/gfx/WEBPTexture.cpp
+++ b/source/gfx/WEBPTexture.cpp
@@ -1,73 +1,29 @@
 #include "WEBPTexture.h"
-#include "utils/logger.h"
-#include <cstdlib>
-#include <cstring>
-#include <gx2/mem.h>
+#include <stdexcept>
 #include <webp/decode.h>
 
-GX2Texture *WEBP_LoadTexture(std::span<uint8_t> data) {
-    GX2Texture *texture = nullptr;
-    int width, height;
+using namespace std::literals;
 
-    if (!WebPGetInfo(data.data(), data.size(), &width, &height)) {
-        DEBUG_FUNCTION_LINE_ERR("Failed to parse WEBP header\n");
-        goto error;
+std::expected<Texture, std::string> WEBP_LoadTexture(std::span<const uint8_t> data) noexcept {
+    try {
+        int width, height;
+
+        if (!WebPGetInfo(data.data(), data.size(), &width, &height)) {
+            throw std::runtime_error{"Failed to parse WEBP header"};
+        }
+
+        Texture texture(width, height);
+
+        if (!WebPDecodeRGBAInto(data.data(), data.size(),
+                                reinterpret_cast<uint8_t *>(texture.getPixels()),
+                                texture.getSize(),
+                                texture.getRowStride())) {
+            throw std::runtime_error{"Failed to decode WEBP image"};
+        }
+
+        texture.flush();
+        return texture;
+    } catch (std::exception &e) {
+        return std::unexpected{"[WEBPTexture] "s + e.what()};
     }
-
-    texture = static_cast<GX2Texture *>(std::malloc(sizeof(GX2Texture)));
-    if (!texture) {
-        DEBUG_FUNCTION_LINE_ERR("Failed to allocate texture\n");
-        goto error;
-    }
-
-    std::memset(texture, 0, sizeof(GX2Texture));
-    texture->surface.width     = width;
-    texture->surface.height    = height;
-    texture->surface.depth     = 1;
-    texture->surface.mipLevels = 1;
-    texture->surface.format    = GX2_SURFACE_FORMAT_UNORM_R8_G8_B8_A8;
-    texture->surface.aa        = GX2_AA_MODE1X;
-    texture->surface.use       = GX2_SURFACE_USE_TEXTURE;
-    texture->surface.dim       = GX2_SURFACE_DIM_TEXTURE_2D;
-    texture->surface.tileMode  = GX2_TILE_MODE_LINEAR_ALIGNED;
-    texture->surface.swizzle   = 0;
-    texture->viewFirstMip      = 0;
-    texture->viewNumMips       = 1;
-    texture->viewFirstSlice    = 0;
-    texture->viewNumSlices     = 1;
-    texture->compMap           = 0x0010203;
-    GX2CalcSurfaceSizeAndAlignment(&texture->surface);
-    GX2InitTextureRegs(texture);
-
-    if (texture->surface.imageSize == 0) {
-        DEBUG_FUNCTION_LINE_ERR("Texture is empty\n");
-        goto error;
-    }
-
-    texture->surface.image = std::aligned_alloc(texture->surface.alignment,
-                                                texture->surface.imageSize);
-    if (!texture->surface.image) {
-        DEBUG_FUNCTION_LINE_ERR("Failed to allocate surface for texture\n");
-        goto error;
-    }
-
-    if (!WebPDecodeRGBAInto(data.data(), data.size(),
-                            reinterpret_cast<uint8_t *>(texture->surface.image),
-                            texture->surface.imageSize,
-                            texture->surface.pitch * 4)) {
-        DEBUG_FUNCTION_LINE_ERR("Failed to decode WEBP image\n");
-        goto error;
-    }
-
-    GX2Invalidate(GX2_INVALIDATE_MODE_CPU | GX2_INVALIDATE_MODE_TEXTURE,
-                  texture->surface.image, texture->surface.imageSize);
-
-    return texture;
-
-error:
-    if (texture) {
-        std::free(texture->surface.image);
-    }
-    std::free(texture);
-    return nullptr;
 }

--- a/source/gfx/WEBPTexture.h
+++ b/source/gfx/WEBPTexture.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "Texture.h"
 #include <cstdint>
-#include <gx2/texture.h>
+#include <expected>
 #include <span>
+#include <string>
 
-GX2Texture *WEBP_LoadTexture(std::span<uint8_t> data);
+std::expected<Texture, std::string> WEBP_LoadTexture(std::span<const uint8_t> data) noexcept;


### PR DESCRIPTION
Users will download a bunch of images off places like Discord and Reddit, which are known for converting PNG images to WEBP, whilst keeping the `.png` resource name. So users end up downloading a WEBP image named `.png`.

This adds an error reporting screen, when an image fails to load, instead of just silently falling back to another image. The error screen stays up for 15 seconds, which should be enough for the user to write down the name of the "bad" image, and either delete it, or rename it properly.

I also went ahead and did some refactoring to remove code duplication when creating the texture, and turned the explicit error handling with RAII handling. The image loading functions now return a message as the error in a `std::expected` object.